### PR TITLE
ready for PR

### DIFF
--- a/database/seedDBnoSQL.js
+++ b/database/seedDBnoSQL.js
@@ -1,4 +1,3 @@
-/* global describe, xdescribe, beforeAll, afterEach, afterAll, test, expect */
 const { MongoClient } = require('mongodb');
 const fake = require('faker');
 const cluster = require('cluster');
@@ -61,22 +60,6 @@ const insert10kDocsNoConnect = (forTable, collection, cb) => {
   });
 };
 
-const openDbInsert10k = (url, dbname, table, cb) => {
-  MongoClient.connect(url, (error, client) => {
-    if (error) throw error;
-    const db = client.db(dbname);
-    const collection = db.collection(table);
-    insert10kDocsNoConnect(table, collection, (error, result) => {
-      if (error) throw error;
-      const writeResult = result;
-      client.close((error) => {
-        if (error) throw error;
-        cb(writeResult);
-      });
-    });
-  });
-};
-
 const insertBatch = (size, url, dbname, table) => {
   let counter = size;
   MongoClient.connect(url, (error, client) => {
@@ -88,6 +71,7 @@ const insertBatch = (size, url, dbname, table) => {
       if (counter > 1) {
         insert10kDocsNoConnect(table, collection, cb);
       } else {
+        // when finished with batch, close client connection then exit cluster process
         client.close((error, result) => {
           if (error) throw error;
           process.exit();
@@ -126,5 +110,4 @@ const clusterInsert = (url, dbname, table, masterCallback) => {
 
 module.exports.insert10kDocs = insert10kDocs;
 module.exports.insert10kDocsNoConnect = insert10kDocsNoConnect;
-module.exports.openDbInsert10k = openDbInsert10k;
 module.exports.clusterInsert = clusterInsert;


### PR DESCRIPTION
@dpaikoff - 

I confess that I have been bad about pushing to the master branch with this feature, so I've mocked this feature branch. This branch focuses on the scripts in the database folder. Behold:
• createDB.sql - the entry point for seeding the mySQL database. 

	◇ For this to work, you would need to create databases meetup and meetuptest and instantiate the tables using the .sql files createDB.sql and createDBtest.sql. Then you can start up the mysqld service with the default port and host to run the server. Note there are two tables: users and events_users.

	◇ Note that this is a single-threaded process.

	◇ seedDB10M.js is where all of the helper functions live. The basic strategy is to create an array of data using the faker module. Then data is inserting 100k records at a time using callbacks and a counter.

• seedMongoUsers and seedMongoEventsUsers - entry point for seeding the mongo database.

	◇ No preliminary setup, mongo will create the databases as needed.

	◇ seedDBnoSQL - helper functions for seeding. Uses the node cluster module for inserting records with multiple logical cores. Data is still generated and inserted 100k records in sequence using callbacks.